### PR TITLE
fix: subcomponents detection

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,10 +6,12 @@ export const decorators = [(renderStory: Function) => <ThemeWrapper>{renderStory
 
 function ThemeWrapper(props: { children: React.ReactNode }) {
   return (
-    <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
+    <div id="root">
       {/* temporary workaround until S2D supports SB7 default root `#storybook-root` */}
       {/* TODO: remove when `#storybook-root` is supported */}
-      <div id="root">{props.children}</div>
-    </MantineProvider>
+      <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
+        {props.children}
+      </MantineProvider>
+    </div>
   );
 }


### PR DESCRIPTION
`#root` workaround interfered with stoty.to.design subcomponents detection logic, so to make it work I need to put it to the real root instead of inside the MantineProvider.