### PR TITLE
fix: type check .storybook files in VSCode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": [".storybook/*", "**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
     "strict": true,


### PR DESCRIPTION
VSCode TSServer unlike `tsc` compiler ignores local `tsconfig.json` for folders starting with `.`, so they need to be explicitly included, otherwise VSCode will use some default tsconfig with wrong configuration and there will be weird errors which are extremely hard to debug. Since `.storybook` dir is now TS based, I ran into some weird type errors with it until found this solution.