### PR TITLE
fix: remove SB7 workaround

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,12 +6,8 @@ export const decorators = [(renderStory: Function) => <ThemeWrapper>{renderStory
 
 function ThemeWrapper(props: { children: React.ReactNode }) {
   return (
-    <div id="root">
-      {/* temporary workaround until S2D supports SB7 default root `#storybook-root` */}
-      {/* TODO: remove when `#storybook-root` is supported */}
-      <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
-        {props.children}
-      </MantineProvider>
-    </div>
+    <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
+      {props.children}
+    </MantineProvider>
   );
 }


### PR DESCRIPTION
S2D now supports Storybook 7 out of the box. No need to define a wrapper with the Storybook 7 `#root`.